### PR TITLE
Release `1.0.0-pre5`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,18 +19,11 @@
  */
 
 
-buildscript {
+buildscript { final scriptHandler ->
     apply from: 'version.gradle'
     apply from: "$rootDir/config/gradle/dependencies.gradle"
 
-    repositories {
-        jcenter()
-        maven { url = repos.gradlePlugins }
-        maven { url = repos.spine }
-        maven { url = repos.spineSnapshots }
-        mavenCentral()
-        mavenLocal()
-    }
+    defaultRepositories(scriptHandler)
 
     dependencies {
         classpath deps.build.guava
@@ -38,6 +31,8 @@ buildscript {
         classpath deps.build.gradlePlugins.protobuf
         classpath "io.spine.tools:spine-model-compiler:$spineBaseVersion"
     }
+
+    forceConfiguration(scriptHandler)
 }
 
 ext {
@@ -85,13 +80,7 @@ subprojects {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 
-    repositories {
-        jcenter()
-        maven { url = repos.spine }
-        maven { url = repos.spineSnapshots }
-        mavenCentral()
-        mavenLocal()
-    }
+    defaultRepositories(project)
 
     dependencies {
         errorprone deps.build.errorProneCore
@@ -103,12 +92,20 @@ subprojects {
         implementation deps.build.guava
 
         testImplementation deps.test.hamcrest
-        testImplementation "io.spine:spine-testutil-server:1.0.0-SNAPSHOT"
+        testImplementation "io.spine:spine-testutil-server:$spineVersion"
         testImplementation deps.test.guavaTestlib
         testImplementation deps.test.slf4j
         testImplementation deps.test.junit5Api
         testImplementation deps.test.junit5Runner
     }
+    
+    configurations {
+        // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
+        runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+        testRuntime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+    }
+
+    forceConfiguration(project)
 
     test {
         useJUnitPlatform {
@@ -157,17 +154,17 @@ subprojects {
 
     task sourceJar(type: Jar) {
         from sourceSets.main.allJava
-        classifier "sources"
+        archiveClassifier.set("sources")
     }
 
     task testOutputJar(type: Jar) {
         from sourceSets.test.output
-        classifier "test"
+        archiveClassifier.set("test")
     }
 
     task javadocJar(type: Jar, dependsOn: 'javadoc') {
         from ("$projectDir/build/docs/javadoc")
-        classifier "javadoc"
+        archiveClassifier.set("javadoc")
     }
 
     apply from: deps.scripts.pmd

--- a/firebase-mirror/build.gradle
+++ b/firebase-mirror/build.gradle
@@ -18,6 +18,48 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// In `config/gradle/dependencies.gradle` we define a fail-upon-dependency-conflict strategy.
+// `firebaseAdmin` dependency has multiple conflicting versions in their dependency tree,
+//
+// Therefore this block forces the versions specific to `firebaseAdmin` dependency tree.
+//
+// TODO:2019-02-20:alex.tymchenko: https://github.com/SpineEventEngine/firebase-storage/issues/8
+
+final grpcVersion = "1.18.0"
+final googleClientVersion = "1.25.0"
+final googleAuthLibraryVersion = "0.11.0"
+final nettyVersion = "4.1.27.Final"
+
+configurations.all {
+    resolutionStrategy {
+        force(
+                "com.google.code.gson:gson:2.7",
+                "com.google.api:api-common:1.7.0",
+                "com.google.api-client:google-api-client:$googleClientVersion",
+                "com.google.api.grpc:proto-google-common-protos:1.12.0",
+                "com.google.auth:google-auth-library-oauth2-http:$googleAuthLibraryVersion",
+                "com.google.auth:google-auth-library-credentials:$googleAuthLibraryVersion",
+                "com.google.oauth-client:google-oauth-client:$googleClientVersion",
+                "com.google.http-client:google-http-client:$googleClientVersion",
+                "com.google.http-client:google-http-client-jackson2:$googleClientVersion",
+                
+                "io.grpc:grpc-stub:$grpcVersion",
+                "io.grpc:grpc-core:$grpcVersion",
+                "io.grpc:grpc-protobuf:$grpcVersion",
+                "io.grpc:grpc-context:$grpcVersion",
+                "io.grpc:grpc-netty-shaded:$grpcNettyShadedVersion",
+                
+                "io.opencensus:opencensus-api:0.15.0",
+                
+                "io.netty:netty-codec-http:$nettyVersion",
+                "io.netty:netty-handler:$nettyVersion",
+                "io.netty:netty-transport:$nettyVersion",
+                
+                "org.checkerframework:checker-compat-qual:2.5.3",
+        )
+    }
+}
+
 dependencies {
     implementation deps.build.firebaseAdmin
     implementation "io.grpc:grpc-netty-shaded:$grpcNettyShadedVersion"

--- a/firebase-mirror/src/main/java/io/spine/server/firebase/FirebaseSubscriptionMirror.java
+++ b/firebase-mirror/src/main/java/io/spine/server/firebase/FirebaseSubscriptionMirror.java
@@ -352,7 +352,7 @@ public final class FirebaseSubscriptionMirror {
 
     private static String toKey(Target target) {
         TypeUrl typeUrl = TypeUrl.parse(target.getType());
-        String type = typeUrl.getPrefix() + '_' + typeUrl.getTypeName();
+        String type = typeUrl.prefix() + '_' + typeUrl.toTypeName().value();
         return type;
     }
 

--- a/firebase-mirror/src/main/java/io/spine/server/firebase/UpdateObserver.java
+++ b/firebase-mirror/src/main/java/io/spine/server/firebase/UpdateObserver.java
@@ -95,7 +95,7 @@ abstract class UpdateObserver<U>
         String typeUrl = topic.getTarget()
                               .getType();
         Class<?> targetClass = TypeUrl.parse(typeUrl)
-                                      .getJavaClass();
+                                      .toJavaClass();
         boolean result = EventMessage.class.isAssignableFrom(targetClass);
         return result;
     }

--- a/firebase-mirror/src/test/java/io/spine/server/firebase/FirebaseSubscriptionMirrorTest.java
+++ b/firebase-mirror/src/test/java/io/spine/server/firebase/FirebaseSubscriptionMirrorTest.java
@@ -494,7 +494,7 @@ class FirebaseSubscriptionMirrorTest {
             throws ExecutionException,
                    InterruptedException {
         TypeUrl typeUrl = TypeUrl.of(msgClass);
-        String collectionName = typeUrl.getPrefix() + '_' + typeUrl.getTypeName();
+        String collectionName = typeUrl.prefix() + '_' + typeUrl.toTypeName().value();
         QuerySnapshot collection = collectionAccess.apply(collectionName)
                                                    .get()
                                                    .get();

--- a/firebase-mirror/src/test/java/io/spine/server/firebase/given/FirebaseMirrorTestEnv.java
+++ b/firebase-mirror/src/test/java/io/spine/server/firebase/given/FirebaseMirrorTestEnv.java
@@ -22,6 +22,7 @@ package io.spine.server.firebase.given;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
 import com.google.common.base.Splitter;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.firebase.FirebaseApp;
@@ -156,11 +157,16 @@ public final class FirebaseMirrorTestEnv {
     }
 
     private static Firestore createFirestore(GoogleCredentials credentials) {
-        FirebaseOptions options = new FirebaseOptions
-                .Builder()
-                .setDatabaseUrl(DATABASE_URL)
-                .setCredentials(credentials)
-                .build();
+        FirestoreOptions firestoreOptions =
+                FirestoreOptions.newBuilder()
+                                .setTimestampsInSnapshotsEnabled(true)
+                                .build();
+        FirebaseOptions options =
+                FirebaseOptions.builder()
+                               .setDatabaseUrl(DATABASE_URL)
+                               .setCredentials(credentials)
+                               .setFirestoreOptions(firestoreOptions)
+                               .build();
         FirebaseApp.initializeApp(options);
         Firestore firestore = FirestoreClient.getFirestore();
         return firestore;

--- a/version.gradle
+++ b/version.gradle
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-final def SPINE_VERSION = '1.0.0-pre4'
+final def SPINE_VERSION = '1.0.0-pre5'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR updates the library version to `1.0.0-pre5`.

From now on, there may be no conflicting versions of the same library on classpath. However, as a Firebase Admin SDK artifact has some conflicts, their versions were forced for now (see #8).

The usage of `base` API were updated.